### PR TITLE
Support for linux kernel 5.8 and greater

### DIFF
--- a/Driver/Source.Plx6000_NT/Driver.c
+++ b/Driver/Source.Plx6000_NT/Driver.c
@@ -52,7 +52,7 @@
 #include <linux/module.h>
 #include <linux/sched.h>
 #include <linux/version.h>
-#include <linux/vermagic.h>
+#include <generated/utsrelease.h>
 #include "ApiFunc.h"
 #include "Dispatch.h"
 #include "Driver.h"

--- a/Driver/Source.Plx8000_DMA/Driver.c
+++ b/Driver/Source.Plx8000_DMA/Driver.c
@@ -52,7 +52,7 @@
 #include <linux/module.h>
 #include <linux/sched.h>
 #include <linux/version.h>
-#include <linux/vermagic.h>
+#include <generated/utsrelease.h>
 #include "ApiFunc.h"
 #include "Dispatch.h"
 #include "Driver.h"

--- a/Driver/Source.Plx8000_DMA/SuppFunc.c
+++ b/Driver/Source.Plx8000_DMA/SuppFunc.c
@@ -1012,6 +1012,7 @@ PlxLockBufferAndBuildSgl(
         up_read( &current->mm->mmap_sem );
     #else
         mmap_read_unlock( current->mm );
+    #endif
 
     if (rc != TotalDescr)
     {

--- a/Driver/Source.Plx8000_DMA/SuppFunc.c
+++ b/Driver/Source.Plx8000_DMA/SuppFunc.c
@@ -991,7 +991,11 @@ PlxLockBufferAndBuildSgl(
     }
 
     // Obtain the mmap reader/writer semaphore
-    down_read( &current->mm->mmap_sem );
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+        down_read( &current->mm->mmap_sem );
+    #else
+        mmap_read_lock( current->mm );
+    #endif
 
     // Attempt to lock the user buffer into memory
     rc =
@@ -1004,7 +1008,10 @@ PlxLockBufferAndBuildSgl(
             );
 
     // Release mmap semaphore
-    up_read( &current->mm->mmap_sem );
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+        up_read( &current->mm->mmap_sem );
+    #else
+        mmap_read_unlock( current->mm );
 
     if (rc != TotalDescr)
     {

--- a/Driver/Source.Plx8000_NT/Driver.c
+++ b/Driver/Source.Plx8000_NT/Driver.c
@@ -52,7 +52,7 @@
 #include <linux/module.h>
 #include <linux/sched.h>
 #include <linux/version.h>
-#include <linux/vermagic.h>
+#include <generated/utsrelease.h>
 #include "ApiFunc.h"
 #include "Dispatch.h"
 #include "Driver.h"

--- a/Driver/Source.Plx9000/Dispatch.c
+++ b/Driver/Source.Plx9000/Dispatch.c
@@ -273,12 +273,21 @@ Dispatch_mmap(
      **********************************************************/
 
     // Set the region as page-locked
-    vma->vm_flags |= VM_RESERVED;
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+        vma_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+    #else
+        vma->vm_flags |= VM_RESERVED;
+    #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+    
 
     if (bDeviceMem)
     {
         // Set flag for I/O resource
-        vma->vm_flags |= VM_IO;
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+            vma_flags_set(vma, VM_IO);
+        #else
+            vma->vm_flags |= VM_IO;
+        #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
 
         // Set caching based on BAR properties
         if (pdx->PciBar[offset].Properties.Flags & PLX_BAR_FLAG_PREFETCHABLE)

--- a/Driver/Source.Plx9000/Dispatch.c
+++ b/Driver/Source.Plx9000/Dispatch.c
@@ -274,7 +274,7 @@ Dispatch_mmap(
 
     // Set the region as page-locked
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
-        vma_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+        vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
     #else
         vma->vm_flags |= VM_RESERVED;
     #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
@@ -284,7 +284,7 @@ Dispatch_mmap(
     {
         // Set flag for I/O resource
         #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
-            vma_flags_set(vma, VM_IO);
+            vm_flags_set(vma, VM_IO);
         #else
             vma->vm_flags |= VM_IO;
         #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)

--- a/Driver/Source.Plx9000/Driver.c
+++ b/Driver/Source.Plx9000/Driver.c
@@ -52,7 +52,7 @@
 #include <linux/module.h>
 #include <linux/sched.h>
 #include <linux/version.h>
-#include <linux/vermagic.h>
+#include <generated/utsrelease.h>
 #include "ApiFunc.h"
 #include "Dispatch.h"
 #include "Driver.h"

--- a/Driver/Source.Plx9000/PciFunc.c
+++ b/Driver/Source.Plx9000/PciFunc.c
@@ -885,6 +885,7 @@ PlxProbeForEcamBase(
         Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024 );
     #else
         Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024, 0 );
+    #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
     if (Va_RSDT == NULL)
     {
         goto _Exit_PlxProbeForEcamBase;
@@ -926,6 +927,7 @@ PlxProbeForEcamBase(
             Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200 );
         #else
             Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200, 0 );
+        #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
         if (Va_Table == NULL)
         {
             goto _Exit_PlxProbeForEcamBase;

--- a/Driver/Source.Plx9000/PciFunc.c
+++ b/Driver/Source.Plx9000/PciFunc.c
@@ -881,7 +881,10 @@ PlxProbeForEcamBase(
     pAcpi_Addr_RSDT = (U8*)PLX_INT_TO_PTR( PHYS_MEM_READ_32( (U32*)(pAddress + 16) ) );
 
     // Map RSDT table
-    Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024, 0 );
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
+        Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024 );
+    #else
+        Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024, 0 );
     if (Va_RSDT == NULL)
     {
         goto _Exit_PlxProbeForEcamBase;
@@ -919,7 +922,10 @@ PlxProbeForEcamBase(
         pAddress = (U8*)PLX_INT_TO_PTR( PHYS_MEM_READ_32( (U32*)pEntry ) );
 
         // Map table
-        Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200, 0 );
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
+            Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200 );
+        #else
+            Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200, 0 );
         if (Va_Table == NULL)
         {
             goto _Exit_PlxProbeForEcamBase;

--- a/Driver/Source.Plx9000/PciFunc.c
+++ b/Driver/Source.Plx9000/PciFunc.c
@@ -882,7 +882,7 @@ PlxProbeForEcamBase(
 
     // Map RSDT table
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
-        Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024 );
+        Va_RSDT = ioremap( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024 );
     #else
         Va_RSDT = ioremap_prot( PLX_PTR_TO_INT( pAcpi_Addr_RSDT ), 1024, 0 );
     #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
@@ -924,7 +924,7 @@ PlxProbeForEcamBase(
 
         // Map table
         #if LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)
-            Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200 );
+            Va_Table = ioremap( PLX_PTR_TO_INT( pAddress ), 200 );
         #else
             Va_Table = ioremap_prot( PLX_PTR_TO_INT( pAddress ), 200, 0 );
         #endif // LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)

--- a/Driver/Source.Plx9000/SuppFunc.c
+++ b/Driver/Source.Plx9000/SuppFunc.c
@@ -953,7 +953,11 @@ PlxLockBufferAndBuildSgl(
     }
 
     // Obtain the mmap reader/writer semaphore
-    down_read( &current->mm->mmap_sem );
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+        down_read( &current->mm->mmap_sem );
+    #else
+        mmap_read_lock( current->mm );
+    #endif
 
     // Attempt to lock the user buffer into memory
     rc =
@@ -966,7 +970,11 @@ PlxLockBufferAndBuildSgl(
             );
 
     // Release mmap semaphore
-    up_read( &current->mm->mmap_sem );
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+        up_read( &current->mm->mmap_sem );
+    #else
+        mmap_read_unlock( current->mm );
+    #endif
 
     if (rc != TotalDescr)
     {

--- a/Driver/Source.PlxSvc/Driver.c
+++ b/Driver/Source.PlxSvc/Driver.c
@@ -53,7 +53,7 @@
 #include <linux/init.h>
 #include <linux/slab.h>      // For kmalloc()
 #include <linux/version.h>
-#include <linux/vermagic.h>
+#include <generated/utsrelease.h>
 #include "Dispatch.h"
 #include "Driver.h"
 #include "PciFunc.h"

--- a/Include/Plx_sysdep.h
+++ b/Include/Plx_sysdep.h
@@ -436,8 +436,28 @@
                     (vmas)                              \
                     )                                   \
             )
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,5,0)
+    #define Plx_get_user_pages(start, nr_pages, gup_flags, pages, vmas) \
+            (                                           \
+                get_user_pages(                         \
+                    (start),                            \
+                    (nr_pages),                         \
+                    (gup_flags),                        \
+                    (pages),                            \
+                    (vmas)                              \
+                    )                                   \
+            )
 #else
-    #define Plx_get_user_pages          get_user_pages
+    //For Kernels >= 6.5.0
+    #define Plx_get_user_pages(start, nr_pages, gup_flags, pages, vmas) \
+            (                                           \
+                get_user_pages(                         \
+                    (start),                            \
+                    (nr_pages),                         \
+                    (gup_flags),                        \
+                    (pages)                             \
+                    )                                   \
+            )
 #endif
 
 

--- a/PlxApi/SpiFlash.c
+++ b/PlxApi/SpiFlash.c
@@ -793,7 +793,7 @@ Spi_WaitControllerReady(
         // Verify we don't exceed poll time
         gettimeofday( &endTime, NULL );
         timersub( &startTime, &endTime, &deltaTime);
-        elapsedTimeMs = (U32)( deltaTime.tv_sec*1000 + deltatTime.tv_usec/1000 );
+        elapsedTimeMs = (U32)( deltaTime.tv_sec*1000 + deltaTime.tv_usec/1000 );
         if (elapsedTimeMs >= SPI_MAX_WAIT_CTRL_READY_MS)
         {
             ErrorPrintf((

--- a/PlxApi/SpiFlash.c
+++ b/PlxApi/SpiFlash.c
@@ -49,7 +49,7 @@
 
 
 #include <string.h>     // For memset()/memcpy()
-#include <sys/timeb.h>  // For ftime()
+#include <sys/time.h>  // For getttimeofday()
 #include "SpiFlash.h"
 #include "PlxApiDebug.h"
 
@@ -764,12 +764,13 @@ Spi_WaitControllerReady(
     U32          regVal;
     U32          elapsedTimeMs;
     PLX_STATUS   status;
-    struct timeb endTime;
-    struct timeb startTime;
+    struct timeval endTime;
+    struct timeval startTime;
+    struct timeval deltaTime;
 
 
     // Note start time
-    ftime( &startTime );
+    gettimeofday( &startTime, NULL );
 
     // Wait until command valid is clear
     do
@@ -790,8 +791,9 @@ Spi_WaitControllerReady(
         }
 
         // Verify we don't exceed poll time
-        ftime( &endTime );
-        elapsedTimeMs = (U32)(PLX_DIFF_TIMEB( endTime, startTime ) * 1000);
+        gettimeofday( &endTime, NULL );
+        timersub( &startTime, &endTime, &deltaTime);
+        elapsedTimeMs = (U32)( deltaTime.tv_sec*1000 + deltatTime.tv_usec/1000 );
         if (elapsedTimeMs >= SPI_MAX_WAIT_CTRL_READY_MS)
         {
             ErrorPrintf((


### PR DESCRIPTION
The drivers had issues compiling on kernels newer than 5.8 since there was a change in the mmap locking API. I've made changes such that the driver now compiles on newer kernels. I've been able to compile it on 6.20. Note that I've not yet been able to test it with actual hardware, so it may or may not work. I've marked the PR as draft until I get to test the fix.

# NOTE: Not yet tested